### PR TITLE
Misc test/build tweaks

### DIFF
--- a/chapter-02/colored_code/Cargo.toml
+++ b/chapter-02/colored_code/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "colored-code"
+name = "colored_code"
 version = "0.1.0"
 edition = "2021"
 

--- a/chapter-02/exit_code/tests/test1.rs
+++ b/chapter-02/exit_code/tests/test1.rs
@@ -19,11 +19,6 @@ fn get_program_path() -> String {
 fn terminate_with_success() {
     let out = std::process::Command::new(&get_program_path())
         .arg("success")
-        .output();
-    dbg!(out);
-
-    let out = std::process::Command::new(&get_program_path())
-        .arg("success")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(0));

--- a/chapter-04/rmgui_adder/Cargo.toml
+++ b/chapter-04/rmgui_adder/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gtk = "0.15.5"
+gdk = "0.16.0"
+gdk-pixbuf = "0.16.3"
+gtk = "0.16.1"


### PR DESCRIPTION
in testing for Mac compatibility i found a few minor things that needed to be updated.  I dont believe they are platform-specific.

Otherwise all tests and executions pass on Mac (Ventura M1).  Rust 1.65